### PR TITLE
Change ProductNumber to string to allow 0123 and 123

### DIFF
--- a/Hexio.EconomicClient/ReadModels/ProductReadModel.cs
+++ b/Hexio.EconomicClient/ReadModels/ProductReadModel.cs
@@ -12,7 +12,7 @@ namespace Hexio.EconomicClient.ReadModels
         public string Description { get; set; }
         public Inventory Inventory { get; set; }
         public ProductGroupReadModel ProductGroup { get; set; }
-        public long? ProductNumber { get; set; }
+        public string ProductNumber { get; set; }
         public decimal RecommendedPrice { get; set; }
         public decimal SalesPrice { get; set; }
         public Uri Self { get; set; }


### PR DESCRIPTION
A customer has decided to have productnumbers duplicated as "08445" and "8445"

Hence using a long cannot be done - as 08445 will be deserialized as 8445. 